### PR TITLE
Workaround to disable AKV CSI Driver's monitoring pod

### DIFF
--- a/deploy/2-azure-iot-operations.sh
+++ b/deploy/2-azure-iot-operations.sh
@@ -36,6 +36,13 @@ az iot ops init --cluster $CLUSTER_NAME -g $RESOURCE_GROUP  \
   --kv-id $keyVaultResourceId \
   --no-deploy
 
+# Updating the AKS CSI Driver post-install - this is a workaround to disable a resource intense monitoring Pod
+echo "Updating the AKS CSI Driver post-install"
+az k8s-extension update --cluster-name $CLUSTER_NAME --resource-group $RESOURCE_GROUP \
+    --cluster-type connectedClusters \
+    --name akvsecretsprovider \
+    --configuration-settings arc.enableMonitoring=false --yes
+
 echo "Installing Azure IoT Operations Preview components using ARM template for more control"
 az deployment group create \
     --resource-group $RESOURCE_GROUP \


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
In current AKV CSI Driver Arc Extension which is deployed as part of initialization `az iot ops init` command, the Monitoring pod is taking a lot of CPU cycles.
As a temporary workaround we update the Arc Extension to configure the underlying Helm chart (see https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-akv-secrets-provider#additional-configuration-options). This allows customizing the configuration without having to revert to full manual Azure IoT Operations initialization steps.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Only thing you should notice is that the pod for arc monitoring gets removed via the Arc extension (in kube-system namespace)