### PR TITLE
Upgrading versions and env use to remove workflow warnings

### DIFF
--- a/.github/workflows/create-tag.yaml
+++ b/.github/workflows/create-tag.yaml
@@ -10,21 +10,21 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.7
+      uses: gittools/actions/gitversion/setup@v0.11.0
       with:
         versionSpec: '5.x'
     - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v0.9.7
+      uses: gittools/actions/gitversion/execute@v0.11.0
       with:
         useConfigFile: true
     - name: Create git tag
       run: |
-        git tag $GITVERSION_MAJORMINORPATCH
+        git tag ${{ env.GitVersion_MajorMinorPatch }}
       if: github.ref == 'refs/heads/main'
     - name: Push git tag
-      run: git push origin $GITVERSION_MAJORMINORPATCH
+      run: git push origin ${{ env.GitVersion_MajorMinorPatch }}
       if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Upgrade the task versions used in Workflow create-tag to remove the warnings around NodeJS 16 deprecation. Done by @syedhassaanahmed in our other repo and relevant to apply to this repo as well.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type


<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
See the repo which now has no more warnings when running create-tag.yaml workflow: 

https://github.com/Azure-Samples/azure-edge-extensions-aksee-proxy-certs/actions/runs/8051409534 << old
https://github.com/Azure-Samples/azure-edge-extensions-aksee-proxy-certs/actions/runs/8052500543 << current
