### PR TITLE
AIO deployment of Otel collector changed, prevent competing Helm targets

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,9 +16,5 @@ RUN wget https://github.com/EdJoPaTo/mqttui/releases/download/v0.19.0/mqttui-v0.
     sudo apt-get install ./mqttui-v0.19.0-x86_64-unknown-linux-gnu.deb && \
     rm -rf ./mqttui-v0.19.0-x86_64-unknown-linux-gnu.deb
 
-# Install cmctl - cert-manager's CLI
-RUN cd /usr/bin && \
-    curl -fsSL https://github.com/cert-manager/cert-manager/releases/latest/download/cmctl-linux-amd64.tar.gz | tar xzv --no-anchored cmctl
-
 # Install Flux CLI
 RUN curl -s https://fluxcd.io/install.sh | FLUX_VERSION=2.0.0 bash

--- a/deploy/2-azure-iot-operations.sh
+++ b/deploy/2-azure-iot-operations.sh
@@ -47,6 +47,8 @@ echo "Installing Azure IoT Operations Preview components using ARM template to c
 echo "Settings include:"
 echo "- MQ adding the property 'openTelemetryTracesCollectorAddr'"
 echo "- OPC UA Broker extension setting 'opcPlcSimulation.autoAcceptUntrustedCertificates' property to true for testing"
+echo "- Removed the deployment of Otel Collector in default template, will do this in step 4"
+# Removed the "[variables('observability_helmChart')]" from the target '[parameters('targetName')]'"
 az deployment group create \
     --resource-group $RESOURCE_GROUP \
     --name aio-$deploymentName \

--- a/deploy/templates/azureiotops-edited.json
+++ b/deploy/templates/azureiotops-edited.json
@@ -643,7 +643,6 @@
       "name": "[parameters('targetName')]",
       "properties": {
         "components": [
-          "[variables('observability_helmChart')]",
           "[variables('akri_daemonset')]",
           "[variables('asset_configuration')]",
           "[variables('broker_fe_issuer_configuration')]"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Removed unnecessary devcontainer dockerfile cli installation for `cmctl` (which has changed release, and was failing)
* Updated base AIO ARM deployment to remove initial Otel Helm chart (target) deployment, which was causing Orchestrator race condition

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
## How to Test
Follow the Readme.me guide, and test Grafana is still working with data from local observability by:
1. Stop the K3D cluster: `k3d cluster stop devcluster`
2. Wait a few minutes
3. Restart the cluster `k3d cluster start devcluster`
4. Validate all pods in `azure-iot-operations` and `edge-observability` are running after a minute or so
5. Follow the steps to go into Grafana dashboard and validate data is flowing, with a noticeable interruption when you stopped the cluster.
